### PR TITLE
Add support for `agda-stdlib-classes`

### DIFF
--- a/nix/agda-with-stdlib.nix
+++ b/nix/agda-with-stdlib.nix
@@ -3,4 +3,6 @@
 let
   stdlib = repoRoot.nix.agda-stdlib;
   iog-prelude = repoRoot.nix.iog-prelude;
-in repoRoot.nix.agda-packages.agda.withPackages [ stdlib iog-prelude ]
+  agda-stdlib-classes = repoRoot.nix.agda-stdlib-classes;
+in
+repoRoot.nix.agda-packages.agda.withPackages [ stdlib agda-stdlib-classes iog-prelude ]

--- a/nix/ouroboros-praos-formal-spec.nix
+++ b/nix/ouroboros-praos-formal-spec.nix
@@ -5,7 +5,7 @@ repoRoot.nix.agda-packages.mkDerivation {
   pname = "ouroboros-praos-formal-spec";
   src = ./..;
   meta = { description = "Ouroboros Praos formal specification"; };
-  buildInputs = [ repoRoot.nix.agda-stdlib repoRoot.nix.iog-prelude ];
+  buildInputs = [ repoRoot.nix.agda-stdlib repoRoot.nix.iog-prelude repoRoot.nix.agda-stdlib-classes ];
   everythingFile = "./src/Everything.agda";
   preBuild = ''
     # Create the missing everything file.

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -10,6 +10,7 @@ cabalProject:
     # Agda packages.
     repoRoot.nix.agda-with-stdlib
     repoRoot.nix.agda-stdlib
+    repoRoot.nix.agda-stdlib-classes
     repoRoot.nix.iog-prelude
     repoRoot.nix.emacs-with-packages
 

--- a/ouroboros-praos-formal-spec.agda-lib
+++ b/ouroboros-praos-formal-spec.agda-lib
@@ -1,5 +1,5 @@
 name: ouroboros-praos-formal-spec
-depend: standard-library iog-prelude
+depend: standard-library standard-library-classes iog-prelude
 include: src
 flags: --erasure
 


### PR DESCRIPTION
The purpose of this PR is to add support for the use of `agda-stdlib-classes`.