### PR TITLE
Move `honestGlobalTreeInHonestLocalTree` to a separate liveness directory

### DIFF
--- a/src/Properties/Base/Trees.agda
+++ b/src/Properties/Base/Trees.agda
@@ -20,6 +20,7 @@ open import Protocol.Semantics ⦃ params ⦄ ⦃ assumptions ⦄
 open import Properties.Base.Time ⦃ params ⦄ ⦃ assumptions ⦄
 open import Properties.Base.LocalState ⦃ params ⦄ ⦃ assumptions ⦄
 open import Properties.Base.ExecutionOrder ⦃ params ⦄ ⦃ assumptions ⦄
+open import Properties.Liveness.ChainGrowth ⦃ params ⦄ ⦃ assumptions ⦄ using (honestGlobalTreeInHonestLocalTree)
 open import Prelude.AssocList.Properties.Ext using (set-⁉; map-⁉-∈-just)
 open import Data.List.Relation.Binary.BagAndSetEquality using (∷-cong; concat-cong; map-cong; bag-=⇒; ↭⇒∼bag)
 open import Data.Maybe.Properties.Ext using (Is-just⇒to-witness; ≡just⇒Is-just)
@@ -323,16 +324,6 @@ honestLocalTreeBlocksMonotonicity N₀↝⋆N hp lspN N↝⋆N′ = honestLocalT
         goal (advanceRound   _) = ih lspN′
         goal (permuteParties _) = ih lspN′
         goal (permuteMsgs    _) = ih lspN′
-
-honestGlobalTreeInHonestLocalTree : ∀ {N N′ : GlobalState} {p : Party} {ls : LocalState} →
-    N₀ ↝⋆ N
-  → Honest p
-  → N .progress ≡ ready
-  → N′ .progress ≡ msgsDelivered
-  → N ↝⋆⟨ 0 ⟩ N′
-  → N′ .states ⁉ p ≡ just ls
-  → allBlocks (honestTree N) ⊆ˢ allBlocks (ls .tree)
-honestGlobalTreeInHonestLocalTree = {!!}
 
 honestGlobalTreeInHonestLocalTree-↝⋆⟨1⟩ : ∀ {N N′ : GlobalState} {p : Party} {ls′ : LocalState} →
     N₀ ↝⋆ N

--- a/src/Properties/Liveness/ChainGrowth.agda
+++ b/src/Properties/Liveness/ChainGrowth.agda
@@ -1,0 +1,23 @@
+{-# OPTIONS --allow-unsolved-metas #-} -- TODO: Remove when holes are filled
+
+open import Protocol.Assumptions using (Assumptions)
+open import Protocol.Params using (Params)
+
+module Properties.Liveness.ChainGrowth
+  ⦃ params : _ ⦄ (open Params params)
+  ⦃ assumptions : Assumptions ⦃ params ⦄ ⦄ (open Assumptions assumptions)
+  where
+
+open import Protocol.Prelude
+open import Protocol.TreeType ⦃ params ⦄
+open import Protocol.Semantics ⦃ params ⦄ ⦃ assumptions ⦄
+
+honestGlobalTreeInHonestLocalTree : ∀ {N N′ : GlobalState} {p : Party} {ls : LocalState} →
+    N₀ ↝⋆ N
+  → Honest p
+  → N .progress ≡ ready
+  → N′ .progress ≡ msgsDelivered
+  → N ↝⋆⟨ 0 ⟩ N′
+  → N′ .states ⁉ p ≡ just ls
+  → allBlocks (honestTree N) ⊆ˢ allBlocks (ls .tree)
+honestGlobalTreeInHonestLocalTree = {!!}

--- a/src/Properties/Safety/BlockPositions.agda
+++ b/src/Properties/Safety/BlockPositions.agda
@@ -25,6 +25,7 @@ open import Properties.Base.CollisionFree ⦃ params ⦄ ⦃ assumptions ⦄
 open import Properties.Base.BlockHistory ⦃ params ⦄ ⦃ assumptions ⦄
 open import Properties.Base.ExecutionOrder ⦃ params ⦄ ⦃ assumptions ⦄
 open import Properties.Base.Time ⦃ params ⦄ ⦃ assumptions ⦄
+open import Properties.Liveness.ChainGrowth ⦃ params ⦄ ⦃ assumptions ⦄ using (honestGlobalTreeInHonestLocalTree)
 open import Data.Nat.Properties.Ext using (pred[n]<n; suc-≢-injective)
 open import Data.Sum.Algebra.Ext using (¬A⊎B⇒A→B)
 open import Data.List.Properties.Ext using ([]≢∷ʳ; ≢[]⇒∷; ∷≢[]; length0⇒[]; filter-acceptʳ; filter-rejectʳ)


### PR DESCRIPTION
This PR moves the `honestGlobalTreeInHonestLocalTree` lemma to a separate directory related to the Liveness property, since morally it's part of the proof of the Chain Growth property.